### PR TITLE
🚀 feat(tools): Add OVERLOCK export to local.mk

### DIFF
--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -42,6 +42,7 @@ export KUBECTL
 export KUSTOMIZE
 export HELM
 export HELM3
+export OVERLOCK
 export USE_HELM3
 export GOMPLATE
 export ISTIO


### PR DESCRIPTION
Fixes #2

Adds `export OVERLOCK` to the tool exports section in `makelib/local.mk` to make the OVERLOCK tool available to parent Makefiles.

The OVERLOCK tool was already defined in `makelib/k8s_tools.mk` with a working installation target, but was missing from the exports in `local.mk`, preventing it from being accessible in parent Makefiles.

## Changes
- Added `export OVERLOCK` to the exports section (lines 39-46)

## Testing
- OVERLOCK variable is now exported and available to parent Makefiles
- Installation target remains functional as before